### PR TITLE
Patch Gin issue 3419904

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
                 "Issue #3267304: Infer target_revision_id to be Latest Revision when Only a target_id is Provided": "https://www.drupal.org/files/issues/2022-05-13/3267304-9.patch"
             },
             "drupal/gin": {
-                "Issue #334216: Remove implicit dependency on node module for gin content form.": "https://www.drupal.org/files/issues/2024-01-15/3342164-6.patch",
+                "Issue #3342164: Remove implicit dependency on node module for gin content form.": "https://www.drupal.org/files/issues/2024-01-15/3342164-6.patch",
                 "Issue #3419904: Help text is cutoff at xsmall breakpoint.": "https://www.drupal.org/files/issues/2024-02-07/3419904-4.patch"
             },
             "drupal/jsonapi_schema": {

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,8 @@
                 "Issue #3267304: Infer target_revision_id to be Latest Revision when Only a target_id is Provided": "https://www.drupal.org/files/issues/2022-05-13/3267304-9.patch"
             },
             "drupal/gin": {
-                "Issue #334216: Remove implicit dependency on node module for gin content form.": "https://www.drupal.org/files/issues/2024-01-15/3342164-6.patch"
+                "Issue #334216: Remove implicit dependency on node module for gin content form.": "https://www.drupal.org/files/issues/2024-01-15/3342164-6.patch",
+                "Issue #3419904: Help text is cutoff at xsmall breakpoint.": "https://www.drupal.org/files/issues/2024-02-07/3419904-4.patch"
             },
             "drupal/jsonapi_schema": {
                 "Issue #3256795: Float fields have a null schema": "https://www.drupal.org/files/issues/2022-01-03/3256795-4.patch",


### PR DESCRIPTION
This fixes an issue where help text is cutoff at the top of the page on xsmall/mobile screen sizes

Issue: https://www.drupal.org/project/gin/issues/3419904